### PR TITLE
Fix typos, extend doc strings, updated endpoints to Kraken's Spot changelog for March 2023

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags: "*"
   pull_request:
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,14 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version:
-          - "1.8"
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x64
+        version: "1.8"
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        arch: x64
     steps:
       - uses: actions/checkout@v1
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: "1.8"
+        version: ["1.8"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        arch: x64
+        arch: [x64]
     steps:
       - uses: actions/checkout@v1
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -7,6 +7,7 @@ on:
     inputs:
       lookback:
         default: 3
+
 permissions:
   actions: read
   checks: read
@@ -20,6 +21,7 @@ permissions:
   repository-projects: read
   security-events: read
   statuses: read
+
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KrakenEx"
 uuid = "905906f8-4650-4186-8b30-13842c9f1f1c"
 authors = ["Benjamin Thomas Schwertfeger"]
-version = "0.1.0"
+version = "1.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -14,12 +14,12 @@ StringEncodings = "69024149-9ee7-55f6-a4c4-859efe599b68"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Documenter = "0.27"
 HTTP = "1"
 JSON = "0.21"
 Nettle = "1"
+StringEncodings = "0.3"
 julia = "1.8"
-StringEncodings = "0.3" 
-Documenter = "0.27"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -20,12 +20,10 @@
 
 </div>
 
-<h3>
-This is an unofficial collection of REST and websocket clients for Spot and Futures trading on the Kraken cryptocurrency exchange using Julia.
+> ⚠️ This is an unofficial collection of REST and websocket clients for Spot and Futures trading on the Kraken cryptocurrency exchange using Julia. Payward Ltd. and Kraken are in no way associated with the authors of this module and documentation.
 
 This project is based on the [python-kraken-sdk](https://github.com/btschwertfeger/python-kraken-sdk).
 
-</h3>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Note: Authenticated Futures websocket clients can also un/subscribe from/to publ
 | `get_ohlc`                | https://docs.kraken.com/rest/#operation/getOHLCData           |
 | `get_order_book`          | https://docs.kraken.com/rest/#operation/getOrderBook          |
 | `get_recent_trades`       | https://docs.kraken.com/rest/#operation/getRecentTrades       |
-| `get_recend_spreads`      | https://docs.kraken.com/rest/#operation/getRecentSpreads      |
+| `get_recent_spreads`      | https://docs.kraken.com/rest/#operation/getRecentSpreads      |
 | `get_system_status`       | checks if Kraken is online                                    |
 
 <a name="spotfunding"></a>
@@ -537,10 +537,10 @@ Note: Authenticated Futures websocket clients can also un/subscribe from/to publ
 | ---------------------------- | ------------------------------------------------------------------ |
 | `get_deposit_methods`        | https://docs.kraken.com/rest/#operation/getDepositMethods          |
 | `get_deposit_address`        | https://docs.kraken.com/rest/#operation/getDepositAddresses        |
-| `get_recend_deposits_status` | https://docs.kraken.com/rest/#operation/getStatusRecentDeposits    |
+| `get_recent_deposits_status` | https://docs.kraken.com/rest/#operation/getStatusRecentDeposits    |
 | `get_withdrawal_info`        | https://docs.kraken.com/rest/#operation/getWithdrawalInformation   |
 | `withdraw_funds`             | https://docs.kraken.com/rest/#operation/withdrawFund               |
-| `get_recend_withdraw_status` | https://docs.kraken.com/rest/#operation/getStatusRecentWithdrawals |
+| `get_recent_withdraw_status` | https://docs.kraken.com/rest/#operation/getStatusRecentWithdrawals |
 | `cancel_withdraw`            | https://docs.kraken.com/rest/#operation/cancelWithdrawal           |
 | `wallet_transfer`            | https://docs.kraken.com/rest/#operation/walletTransfer             |
 
@@ -688,8 +688,6 @@ Note: Authenticated Futures websocket clients can also un/subscribe from/to publ
 <a name="notes"></a>
 
 # 📝 Notes:
-
-- Pull requests will be ignored until the owner finished the core idea
 
 - Coding standards are not always followed to make arguments and function names as similar as possible to those in the Kraken API documentations.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,7 +13,7 @@ Futures and Spot Websocket and REST API Julia SDK for the Kraken Cryptocurrency 
 [![CI](https://github.com/btschwertfeger/KrakenEx.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/btschwertfeger/KrakenEx.jl/actions/workflows/CI.yml)
 [![Documentation](https://github.com/btschwertfeger/KrakenEx.jl/actions/workflows/Documentation.yml/badge.svg)](https://github.com/btschwertfeger/KrakenEx.jl/actions/workflows/Documentation.yml)
 
-This is an unofficial collection of REST and websocket clients for Spot and Futures trading on the Kraken cryptocurrency exchange using Julia.
+> ⚠️ This is an unofficial collection of REST and websocket clients for Spot and Futures trading on the Kraken cryptocurrency exchange using Julia. Payward Ltd. and Kraken are in no way associated with the authors of this module and documentation.
 
 This project is based on the [python-kraken-sdk](https://github.com/btschwertfeger/python-kraken-sdk).
 

--- a/examples/spot_rest_examples.jl
+++ b/examples/spot_rest_examples.jl
@@ -13,7 +13,7 @@ using .KrakenEx.SpotMarketModule:
     get_ohlc,
     get_order_book,
     get_recent_trades,
-    get_recend_spreads,
+    get_recent_spreads,
     get_system_status
 
 using .KrakenEx.SpotUserModule:
@@ -46,10 +46,10 @@ using .KrakenEx.SpotTradeModule:
 using .KrakenEx.SpotFundingModule:
     get_deposit_methods,
     get_deposit_address,
-    get_recend_deposits_status,
+    get_recent_deposits_status,
     withdraw_funds,
     get_withdrawal_info,
-    get_recend_withdraw_status,
+    get_recent_withdraw_status,
     cancel_withdraw,
     wallet_transfer
 
@@ -71,7 +71,7 @@ function market_endpoints(client::SpotBaseRESTAPI)
     println(get_ohlc(client, pair="XBTUSD"))
     println(get_order_book(client, pair="XBTUSD"))
     println(get_recent_trades(client, pair="XBTUSD"))
-    println(get_recend_spreads(client, pair="XBTUSD"))
+    println(get_recent_spreads(client, pair="XBTUSD"))
     println(get_system_status(client))
 end
 
@@ -309,7 +309,7 @@ function funding_endpoints(private_client::SpotBaseRESTAPI)
     #===> F U N D I N G <===#
     println(get_deposit_methods(private_client, asset="DOT"))
     println(get_deposit_address(private_client, asset="DOT", method="Polkadot"))
-    println(get_recend_deposits_status(private_client, asset="DOT", method="Polkadot"))
+    println(get_recent_deposits_status(private_client, asset="DOT", method="Polkadot"))
 
     # if false println(withdraw_funds(private_client, asset="DOT", key="pwallet1", amount=200)) end
 
@@ -323,7 +323,7 @@ function funding_endpoints(private_client::SpotBaseRESTAPI)
             end
         end
     end
-    println(get_recend_withdraw_status(private_client, asset="DOT"))
+    println(get_recent_withdraw_status(private_client, asset="DOT"))
 
     try
         println(cancel_withdraw(private_client, asset="DOT", refid="1234"))

--- a/install.jl
+++ b/install.jl
@@ -1,13 +1,28 @@
 
 #=This file only contains private notes=#
-import Pkg
 
-Pkg.add("HTTP")
-Pkg.add("JSON")
-Pkg.add("PkgTemplates")
-Pkg.add("Nettle")
-Pkg.add("StringEncodings")
 
+## Activate project
+## julia> ]
+## pkg> activate .
+
+## Build project
+## julia> using Pkg; Pkg.build()
+
+## Buikd documentation
+## julia> using Documenter
+## julia> ]
+## pkg> activate .
+## julia> include("docs/make.jl")
+
+
+# import Pkg
+
+# Pkg.add("HTTP")
+# Pkg.add("JSON")
+# Pkg.add("PkgTemplates")
+# Pkg.add("Nettle")
+# Pkg.add("StringEncodings")
 
 # using PkgTemplates
 # t = Template(;

--- a/src/spot/funding.jl
+++ b/src/spot/funding.jl
@@ -10,10 +10,10 @@ using ..Utils
 #======= E X P O R T S ========#
 export get_deposit_methods
 export get_deposit_address
-export get_recend_deposits_status
+export get_recent_deposits_status
 export withdraw_funds
 export get_withdrawal_info
-export get_recend_withdraw_status
+export get_recent_withdraw_status
 export cancel_withdraw
 export wallet_transfer
 
@@ -24,7 +24,7 @@ export wallet_transfer
 Kraken Docs: [https://docs.kraken.com/rest/#operation/getDepositMethods](https://docs.kraken.com/rest/#operation/getDepositMethods)
 
 Returns the available deposit methods for a given `asset` (symbol/currency pair).
-    
+
 Authenticated `client` required
 
 # Examples
@@ -33,9 +33,9 @@ Authenticated `client` required
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> get_deposit_methods(client, asset="DOT")
 Any[Dict{String, Any}(
-    "gen-address" => true, 
-    "method" => 
-    "Polkadot", 
+    "gen-address" => true,
+    "method" =>
+    "Polkadot",
     "limit" => false
 )]
 ```
@@ -46,9 +46,9 @@ end
 
 """
     get_deposit_address(
-        client::SpotBaseRESTAPI; 
-        asset::String, 
-        method::String, 
+        client::SpotBaseRESTAPI;
+        asset::String,
+        method::String,
         new::Bool=false
     )
 
@@ -65,12 +65,12 @@ julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_deposit_address(client, asset="DOT", method="Polkadot"))
 Any[
     Dict{String, Any}(
-        "new" => true, 
-        "expiretm" => "0", 
+        "new" => true,
+        "expiretm" => "0",
         "address" => "14MvdTudtJppS4WrUXg5mQiQiq6baUXt3KwhxxEDXnB7nMYv"
     ), Dict{String, Any}(
-        "new" => true, 
-        "expiretm" => "0", 
+        "new" => true,
+        "expiretm" => "0",
         "address" => "15mK6NDReFAxkP6menxPRZdGNzRJY31vDMe9uSUPWfZj64Vy"
     ), ...
 ]
@@ -88,7 +88,7 @@ function get_deposit_address(
 end
 
 """
-    get_recend_deposits_status(
+    get_recent_deposits_status(
         client::SpotBaseRESTAPI;
         asset::String,
         method::Union{String,Nothing}=nothing
@@ -96,7 +96,7 @@ end
 
 Kraken Docs: [https://docs.kraken.com/rest/#operation/getStatusRecentDeposits](https://docs.kraken.com/rest/#operation/getStatusRecentDeposits)
 
-Returns the status of the recend deposit.
+Returns the status of the recent deposit.
 
 Authenticated `client` required
 
@@ -105,14 +105,14 @@ Authenticated `client` required
 ```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(
-...        get_recend_deposits_status(
+...        get_recent_deposits_status(
 ...             client, asset="DOT", method="Polkadot"
 ...        )
 ...    )
 Any[]
 ```
 """
-function get_recend_deposits_status(
+function get_recent_deposits_status(
     client::SpotBaseRESTAPI;
     asset::String,
     method::Union{String,Nothing}=nothing
@@ -141,9 +141,9 @@ Authenticated `client` required
 ```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(withdraw_funds(
-...         client, 
-...         asset="DOT", 
-...         key="some-widthdrawal-id-from-gui", 
+...         client,
+...         asset="DOT",
+...         key="some-widthdrawal-id-from-gui",
 ...         amount=200
 ...     ))
 Dict{String,Any}("refid" => "AGBSO6T-UFMTTQ-I7KGS6")
@@ -165,8 +165,8 @@ end
 """
     get_withdrawal_info(
         client::SpotBaseRESTAPI;
-        asset::String, 
-        key::String, 
+        asset::String,
+        key::String,
         amount::Union{Float64,Int64,String}
     )
 
@@ -181,9 +181,9 @@ Authenticated `client` required
 ```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_withdrawal_info(
-...        client, 
-...        asset="DOT", 
-...        key="pwallet1", 
+...        client,
+...        asset="DOT",
+...        key="pwallet1",
 ...        amount="200"
 ...    ))
 )
@@ -209,15 +209,15 @@ function get_withdrawal_info(
 end
 
 """
-    get_recend_withdraw_status(
-        client::SpotBaseRESTAPI; 
+    get_recent_withdraw_status(
+        client::SpotBaseRESTAPI;
         asset::String,
         method::Union{String,Nothing}=nothing
     )
 
 Kraken Docs: [https://docs.kraken.com/rest/#operation/getStatusRecentWithdrawals](https://docs.kraken.com/rest/#operation/getStatusRecentWithdrawals)
 
-Returns information about the recend withdrawal.
+Returns information about the recent withdrawal.
 
 Authenticated `client` required
 
@@ -225,7 +225,7 @@ Authenticated `client` required
 
 ```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
-julia> println(get_recend_withdraw_status(client, asset="DOT"))
+julia> println(get_recent_withdraw_status(client, asset="DOT"))
 Dict{String,Any}(
     "method": =>"Bitcoin",
     "aclass" => "currency",
@@ -240,7 +240,7 @@ Dict{String,Any}(
 )
 ```
 """
-function get_recend_withdraw_status(
+function get_recent_withdraw_status(
     client::SpotBaseRESTAPI;
     asset::String,
     method::Union{String,Nothing}=nothing
@@ -293,10 +293,10 @@ Authenticated `client` required
 ```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(wallet_transfer(
-...        client, 
-...        asset="XLM", 
-...        from="Spot Wallet", 
-...        to="Futures Wallet", 
+...        client,
+...        asset="XLM",
+...        from="Spot Wallet",
+...        to="Futures Wallet",
 ...        amount=200
 ...    ))
 Dict{String,Any}("refid" => "AJGLAE5-KSKMGR4-VPNPNV")

--- a/src/spot/funding.jl
+++ b/src/spot/funding.jl
@@ -82,15 +82,15 @@ function get_deposit_address(
     method::String,
     new::Bool=false
 )
-    return request(client, "POST", "/private/DepositAddresses", data=Dict{String,Any}([
+    return request(client, "POST", "/private/DepositAddresses", data=Dict{String,Any}(
             "asset" => asset, "method" => method, "new" => string(new)
-        ]), auth=true)
+        ), auth=true)
 end
 
 """
     get_recent_deposits_status(
         client::SpotBaseRESTAPI;
-        asset::String,
+        asset::Union{String,Nothing}=Nothing,
         method::Union{String,Nothing}=nothing
     )
 
@@ -114,10 +114,11 @@ Any[]
 """
 function get_recent_deposits_status(
     client::SpotBaseRESTAPI;
-    asset::String,
+    asset::Union{String,Nothing}=nothing,
     method::Union{String,Nothing}=nothing
 )
-    params = Dict{String,Any}("asset" => asset)
+    params = Dict{String,Any}()
+    !isnothing(asset) ? params["asset"] = asset : nothing
     !isnothing(method) ? params["method"] = method : nothing
     return request(client, "POST", "/private/DepositStatus", data=params, auth=true)
 end

--- a/src/spot/market.jl
+++ b/src/spot/market.jl
@@ -17,7 +17,7 @@ export get_ticker
 export get_ohlc
 export get_order_book
 export get_recent_trades
-export get_recend_spreads
+export get_recent_spreads
 export get_system_status
 
 #======= F U N C T I O N S ========#
@@ -53,22 +53,22 @@ julia> client = SpotBaseRESTAPI()
 julia> println(get_assets(client))
 Dict{String, Any}(
     "MOVR" => Dict{String, Any}(
-        "display_decimals" => 5, 
-        "decimals" => 10, 
-        "aclass" => "currency", 
-        "status" => "enabled", 
+        "display_decimals" => 5,
+        "decimals" => 10,
+        "aclass" => "currency",
+        "status" => "enabled",
         "altname" => "MOVR"
     ), "SXP" => Dict{String, Any}(
-        "display_decimals" => 5, 
-        "decimals" => 10, 
-        "aclass" => "currency", 
-        "status" => "enabled", 
+        "display_decimals" => 5,
+        "decimals" => 10,
+        "aclass" => "currency",
+        "status" => "enabled",
         "altname" => "SXP"
     ), "PHA" => Dict{String, Any}(
-        "display_decimals" => 5, 
-        "decimals" => 10, 
-        "aclass" => "currency", 
-        "status" => "enabled", 
+        "display_decimals" => 5,
+        "decimals" => 10,
+        "aclass" => "currency",
+        "status" => "enabled",
         "altname" => "PHA"
     ), ...
 )
@@ -100,51 +100,51 @@ julia> client = SpotBaseRESTAPI()
 julia> println(get_tradable_asset_pair(client, pair=["XBTUSD"]))
 Dict{String, Any}(
     "XXBTZUSD" => Dict{String, Any}(
-        "margin_call" => 80, 
-        "leverage_sell" => Any[2, 3, 4, 5], 
-        "cost_decimals" => 5, 
-        "lot_multiplier" => 1, 
-        "long_position_limit" => 270, 
-        "short_position_limit" => 180, 
+        "margin_call" => 80,
+        "leverage_sell" => Any[2, 3, 4, 5],
+        "cost_decimals" => 5,
+        "lot_multiplier" => 1,
+        "long_position_limit" => 270,
+        "short_position_limit" => 180,
         "fees_maker" => Any[
-            Any[0, 0.16], 
-            Any[50000, 0.14], 
-            Any[100000, 0.12], 
-            Any[250000, 0.1], 
-            Any[500000, 0.08], 
-            Any[1000000, 0.06], 
-            Any[2500000, 0.04], 
-            Any[5000000, 0.02], 
-            Any[10000000, 0.0], 
+            Any[0, 0.16],
+            Any[50000, 0.14],
+            Any[100000, 0.12],
+            Any[250000, 0.1],
+            Any[500000, 0.08],
+            Any[1000000, 0.06],
+            Any[2500000, 0.04],
+            Any[5000000, 0.02],
+            Any[10000000, 0.0],
             Any[100000000, 0.0]
-        ], 
-        "ordermin" => "0.0001", 
-        "aclass_base" => "currency", 
-        "fee_volume_currency" => "ZUSD", 
-        "status" => "online", 
-        "altname" => "XBTUSD", 
-        "aclass_quote" => "currency", 
-        "margin_stop" => 40, 
+        ],
+        "ordermin" => "0.0001",
+        "aclass_base" => "currency",
+        "fee_volume_currency" => "ZUSD",
+        "status" => "online",
+        "altname" => "XBTUSD",
+        "aclass_quote" => "currency",
+        "margin_stop" => 40,
         "fees" => Any[
-            Any[0, 0.26], 
+            Any[0, 0.26],
             Any[50000, 0.24],
-            Any[100000, 0.22], 
+            Any[100000, 0.22],
             Any[250000, 0.2],
             Any[500000, 0.18],
             Any[1000000, 0.16],
             Any[2500000, 0.14],
             Any[5000000, 0.12],
-            Any[10000000, 0.1], 
+            Any[10000000, 0.1],
             Any[100000000, 0.08]
-        ], 
-        "quote" => "ZUSD", 
+        ],
+        "quote" => "ZUSD",
         "base" => "XXBT",
-        "lot" => "unit", 
-        "pair_decimals" => 1, 
-        "wsname" => "XBT/USD", 
-        "costmin" => "0.5", 
-        "tick_size" => "0.1", 
-        "lot_decimals" => 8, 
+        "lot" => "unit",
+        "pair_decimals" => 1,
+        "wsname" => "XBT/USD",
+        "costmin" => "0.5",
+        "tick_size" => "0.1",
+        "lot_decimals" => 8,
         "leverage_buy" => Any[2, 3, 4, 5]
     )
 )
@@ -167,19 +167,19 @@ Returns the actual ticker of a given `pair` (asset pair/symbol).
 
 Authenticated `client` not required
 
-# Examples 
+# Examples
 ```julia-repl
 julia> client = SpotBaseRESTAPI()
 julia> println(get_ticker(client, pair="DOTUSD"))
 Dict{String, Any}(
     "DOTUSD" => Dict{String, Any}(
-        "v" => Any["73347.09060256", "831710.16212826"], 
-        "c" => Any["4.91490", "145.01800000"], 
-        "o" => "4.88630", "t" => Any[635, 3486], 
-        "b" => Any["4.91220", "265", "265.000"], 
-        "l" => Any["4.82900", "4.82900"], 
-        "a" => Any["4.91290", "82", "82.000"], 
-        "p" => Any["4.89699", "4.97257"], 
+        "v" => Any["73347.09060256", "831710.16212826"],
+        "c" => Any["4.91490", "145.01800000"],
+        "o" => "4.88630", "t" => Any[635, 3486],
+        "b" => Any["4.91220", "265", "265.000"],
+        "l" => Any["4.82900", "4.82900"],
+        "a" => Any["4.91290", "82", "82.000"],
+        "p" => Any["4.89699", "4.97257"],
         "h" => Any["4.93300", "5.07400"]
     )
 )
@@ -200,18 +200,18 @@ Returns information about the open, high, low, close, vwap, and volume of a give
 
 Authenticated `client` not required
 
-# Examples 
+# Examples
 ```julia-repl
 julia> client = SpotBaseRESTAPI()
 julia> get_ohlc(client, pair="XBTUSD")
 Dict{String, Any}(
     "XXBTZUSD" => Any[
-        Any[1673301660, "17176.5", "17176.5", "17176.4", "17176.5", "17176.4", "0.00499447", 3], 
-        Any[1673301720, "17176.5", "17176.5", "17167.2", "17168.1", "17168.3", "3.57307618", 45], 
-        Any[1673301780, "17168.0", "17168.1", "17167.9", "17168.1", "17167.9", "0.10257254", 16], 
+        Any[1673301660, "17176.5", "17176.5", "17176.4", "17176.5", "17176.4", "0.00499447", 3],
+        Any[1673301720, "17176.5", "17176.5", "17167.2", "17168.1", "17168.3", "3.57307618", 45],
+        Any[1673301780, "17168.0", "17168.1", "17167.9", "17168.1", "17167.9", "0.10257254", 16],
         Any[1673301840, "17168.0", "17176.5", "17168.0", "17176.5", "17176.2", "1.06103454", 19],
-        Any[1673301900, "17176.4", "17176.5", "17176.4", "17176.5", "17176.4", "0.20158908", 4], 
-        Any[1673301960, "17176.5", "17176.5", "17176.4", "17176.5", "17176.4", "0.04299818", 7], 
+        Any[1673301900, "17176.4", "17176.5", "17176.4", "17176.5", "17176.4", "0.20158908", 4],
+        Any[1673301960, "17176.5", "17176.5", "17176.4", "17176.5", "17176.4", "0.04299818", 7],
         ...
     ]
 )
@@ -233,26 +233,26 @@ Returns the current asks and bids (orderbook) of a given currency `pair`.
 
 Authenticated `client` not required
 
-# Examples 
+# Examples
 ```julia-repl
 julia> client = SpotBaseRESTAPI()
 julia> get_order_book(client, pair="XBTUSD")
 Dict{String, Any}(
     "XXBTZUSD" => Dict{String, Any}(
         "asks" => Any[
-            Any["17249.60000", "0.750", 1673344930], Any["17249.80000", "0.038", 1673344927], 
-            Any["17249.90000", "0.067", 1673344930], Any["17250.10000", "0.001", 1673344930], 
-            Any["17250.50000", "4.348", 1673344903], Any["17251.10000", "0.053", 1673344928], 
-            Any["17251.30000", "1.157", 1673344928], Any["17251.50000", "0.807", 1673344930], 
-            Any["17252.40000", "0.369", 1673344921], Any["17252.60000", "0.250", 1673344857], 
+            Any["17249.60000", "0.750", 1673344930], Any["17249.80000", "0.038", 1673344927],
+            Any["17249.90000", "0.067", 1673344930], Any["17250.10000", "0.001", 1673344930],
+            Any["17250.50000", "4.348", 1673344903], Any["17251.10000", "0.053", 1673344928],
+            Any["17251.30000", "1.157", 1673344928], Any["17251.50000", "0.807", 1673344930],
+            Any["17252.40000", "0.369", 1673344921], Any["17252.60000", "0.250", 1673344857],
             ...
         ],
         "bids" => Any[
-            Any["17249.50000", "0.001", 1673344924], 
-            Any["17249.40000", "0.001", 1673344916], 
-            Any["17249.30000", "0.001", 1673344930], 
-            Any["17249.20000", "0.001", 1673344927], 
-            Any["17249.10000", "0.001", 1673344930], 
+            Any["17249.50000", "0.001", 1673344924],
+            Any["17249.40000", "0.001", 1673344916],
+            Any["17249.30000", "0.001", 1673344930],
+            Any["17249.20000", "0.001", 1673344927],
+            Any["17249.10000", "0.001", 1673344930],
             ...
         ]
     )
@@ -281,17 +281,17 @@ julia> client = SpotBaseRESTAPI()
 julia> println(get_recent_trades(client, pair="XBTUSD"))
 Dict{String, Any}(
     "XXBTZUSD" => Any[
-        Any["17265.50000", "0.00515323", 1.673362549987055e9, "b", "l", "", 54454372], 
-        Any["17265.50000", "0.01203124", 1.6733625510070226e9, "b", "l", "", 54454373], 
-        Any["17266.80000", "0.08087410", 1.673362551007105e9, "b", "l", "", 54454374], 
-        Any["17266.90000", "0.56059466", 1.6733625510071838e9, "b", "l", "", 54454375], 
-        Any["17267.00000", "0.00900000", 1.6733625512079215e9, "b", "l", "", 54454376], 
-        Any["17267.00000", "0.00610000", 1.6733625522878373e9, "b", "l", "", 54454377], 
-        Any["17267.00000", "0.00208447", 1.6733625534015026e9, "b", "l", "", 54454378], 
+        Any["17265.50000", "0.00515323", 1.673362549987055e9, "b", "l", "", 54454372],
+        Any["17265.50000", "0.01203124", 1.6733625510070226e9, "b", "l", "", 54454373],
+        Any["17266.80000", "0.08087410", 1.673362551007105e9, "b", "l", "", 54454374],
+        Any["17266.90000", "0.56059466", 1.6733625510071838e9, "b", "l", "", 54454375],
+        Any["17267.00000", "0.00900000", 1.6733625512079215e9, "b", "l", "", 54454376],
+        Any["17267.00000", "0.00610000", 1.6733625522878373e9, "b", "l", "", 54454377],
+        Any["17267.00000", "0.00208447", 1.6733625534015026e9, "b", "l", "", 54454378],
         Any["17268.50000", "0.01211553", 1.6733625534015663e9, "b", "l", "", 54454379],
-        Any["17268.50000", "0.00506894", 1.6733625536050434e9, "b", "l", "", 54454380], 
+        Any["17268.50000", "0.00506894", 1.6733625536050434e9, "b", "l", "", 54454380],
         ...
-    ], 
+    ],
     "last" => "1673363844906015910"
 )
 ```
@@ -303,32 +303,32 @@ function get_recent_trades(client::SpotBaseRESTAPI; pair::String, since::Union{I
 end
 
 """
-    get_recend_spreads(client::SpotBaseRESTAPI; pair::String, since::Union{Int64,Nothing}=nothing)
+    get_recent_spreads(client::SpotBaseRESTAPI; pair::String, since::Union{Int64,Nothing}=nothing)
 
 Kraken Docs: [https://docs.kraken.com/rest/#operation/getRecentSpreads](https://docs.kraken.com/rest/#operation/getRecentSpreads)
 
-Returns the recend spreads of a currency `pair` (symbol).
+Returns the recent spreads of a currency `pair` (symbol).
 
 Authenticated `client` not required
 
 # Examples
 ```julia-repl
 julia> client = SpotBaseRESTAPI()
-julia> println(get_recend_spreads(client, pair="XBTUSD"))
+julia> println(get_recent_spreads(client, pair="XBTUSD"))
 Dict{String, Any}(
     "XXBTZUSD" => Any[
-        Any[1673363656, "17346.40000", "17348.20000"], 
+        Any[1673363656, "17346.40000", "17348.20000"],
         Any[1673363657, "17346.40000", "17347.90000"],
-        Any[1673363657, "17346.80000", "17347.90000"], 
-        Any[1673363660, "17346.80000", "17347.60000"], 
-        Any[1673363660, "17346.40000", "17347.60000"], 
-        Any[1673363660, "17346.50000", "17347.60000"], 
+        Any[1673363657, "17346.80000", "17347.90000"],
+        Any[1673363660, "17346.80000", "17347.60000"],
+        Any[1673363660, "17346.40000", "17347.60000"],
+        Any[1673363660, "17346.50000", "17347.60000"],
         ...
-    ], 
+    ],
     "last" => 1673363958)
 ```
 """
-function get_recend_spreads(client::SpotBaseRESTAPI; pair::String, since::Union{Int64,Nothing}=nothing)
+function get_recent_spreads(client::SpotBaseRESTAPI; pair::String, since::Union{Int64,Nothing}=nothing)
     params = Dict{String,String}("pair" => pair)
     !isnothing(since) ? params["since"] = since : nothing
     return request(client, "GET", "/public/Spread"; data=params, auth=false)

--- a/src/spot/user.jl
+++ b/src/spot/user.jl
@@ -25,6 +25,7 @@ export get_export_report_status
 export retrieve_export
 export delete_export_report
 export get_websockets_token
+export create_subaccount
 
 #======= F U N C T I O N S ========#
 """
@@ -37,19 +38,19 @@ Returns the actual balances of all currencies.
 Authenticated `client` required
 
 # Examples
-```julia-repl 
+```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_account_balance(client))
 Dict{String, Any}(
-    "KFEE" => "9431.54", 
+    "KFEE" => "9431.54",
     "BCH" => "123.0000077100",
-    "ZUSD" => "798.5491", 
-    "XETH" => "14.0119368320", 
-    "DOT" => "671.0153183000", 
-    "ZEUR" => "101.12000", 
-    "XXBT" => "1.0011888110", 
-    "XXLM" => "2030121.00001212", 
-    "EOS" => "24.0000065500", 
+    "ZUSD" => "798.5491",
+    "XETH" => "14.0119368320",
+    "DOT" => "671.0153183000",
+    "ZEUR" => "101.12000",
+    "XXBT" => "1.0011888110",
+    "XXLM" => "2030121.00001212",
+    "EOS" => "24.0000065500",
     "TRX" => "9121230.00000000"
 )
 ```
@@ -71,26 +72,26 @@ Authenticated `client` required
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_trade_balance(client))
 Dict{String, Any}(
-    "v" => "0.0000", 
-    "tb" => "113145.4781", 
-    "mf" => "113145.4781", 
-    "uv" => "0.0000", 
-    "m" => "0.0000", 
-    "c" => "0.0000", 
+    "v" => "0.0000",
+    "tb" => "113145.4781",
+    "mf" => "113145.4781",
+    "uv" => "0.0000",
+    "m" => "0.0000",
+    "c" => "0.0000",
     "e" => "113112.4781",
-    "eb" => "116412.4143", 
+    "eb" => "116412.4143",
     "n" => "0.0000"
 )
 julia> println(get_trade_balance(client, asset="DOT"))
 Dict{String, Any}(
-    "v" => "0.0000000000", 
-    "tb" => "2301.0859297648", 
-    "mf" => "2301.0859297648", 
-    "uv" => "0.0000000000", 
-    "m" => "0.0000000000", 
-    "c" => "0.0000000000", 
-    "e" => "2301.0859297648", 
-    "eb" => "2367.7876343538", 
+    "v" => "0.0000000000",
+    "tb" => "2301.0859297648",
+    "mf" => "2301.0859297648",
+    "uv" => "0.0000000000",
+    "m" => "0.0000000000",
+    "c" => "0.0000000000",
+    "e" => "2301.0859297648",
+    "eb" => "2367.7876343538",
     "n" => "0.0000000000"
 )
 ```
@@ -118,34 +119,34 @@ julia> println(get_open_orders(client))
 Dict{String, Any}(
     "open" => Dict{String, Any}(
         "OAQZLS-7SFKK-PAA6BW" => Dict{String, Any}(
-            "price" => "0.00000", 
-            "vol" => "20.11513967", 
-            "status" => "open", 
-            "vol_exec" => "0.00000000", 
-            "oflags" => "fciq", 
-            "starttm" => 0, 
-            "stopprice" => "0.00000", 
-            "refid" => nothing, 
-            "userref" => 0, 
-            "expiretm" => 0, 
-            "cost" => "0.00000", 
+            "price" => "0.00000",
+            "vol" => "20.11513967",
+            "status" => "open",
+            "vol_exec" => "0.00000000",
+            "oflags" => "fciq",
+            "starttm" => 0,
+            "stopprice" => "0.00000",
+            "refid" => nothing,
+            "userref" => 0,
+            "expiretm" => 0,
+            "cost" => "0.00000",
             "fee" => "0.00000",
-            "misc" => "", 
-            "limitprice" => "0.00000", 
-            "opentm" => 1.6678760796400564e9, 
+            "misc" => "",
+            "limitprice" => "0.00000",
+            "opentm" => 1.6678760796400564e9,
             "descr" => Dict{String, Any}(
-                "ordertype" => "limit", 
-                "price" => "7.1288", 
-                "pair" => "DOTUSD", 
-                "order" => "sell 20.11513967 DOTUSD @ limit 7.1288", 
-                "leverage" => "none", 
-                "type" => "sell", 
-                "close" => "", 
+                "ordertype" => "limit",
+                "price" => "7.1288",
+                "pair" => "DOTUSD",
+                "order" => "sell 20.11513967 DOTUSD @ limit 7.1288",
+                "leverage" => "none",
+                "type" => "sell",
+                "close" => "",
                 "price2" => "0"
             )
-        ), 
+        ),
         "OPNPFB-NRZY3-O6T46Y" => Dict{String, Any}(
-            "price" => "0.00000", 
+            "price" => "0.00000",
             ...
         )
     )
@@ -170,7 +171,7 @@ end
 
 Kraken Docs: [https://docs.kraken.com/rest/#operation/getClosedOrders](https://docs.kraken.com/rest/#operation/getClosedOrders)
 
-Returns information about the closed orders. 
+Returns information about the closed orders.
 
 Authenticated `client` required
 
@@ -182,34 +183,34 @@ julia> println(get_closed_orders(client))
 Dict{String, Any}(
     "closed" => Dict{String, Any}(
         "OLGRP5-M42MC-YOFF7T" => Dict{String, Any}(
-            "price" => "0.00000", 
-            "vol" => "40.36280000", 
-            "status" => "canceled", 
-            "vol_exec" => "0.00000000", 
-            "oflags" => "fciq", 
-            "reason" => "User requested", 
-            "starttm" => 0, 
-            "stopprice" => "0.00000", 
-            "refid" => nothing, 
-            "userref" => 0, 
+            "price" => "0.00000",
+            "vol" => "40.36280000",
+            "status" => "canceled",
+            "vol_exec" => "0.00000000",
+            "oflags" => "fciq",
+            "reason" => "User requested",
+            "starttm" => 0,
+            "stopprice" => "0.00000",
+            "refid" => nothing,
+            "userref" => 0,
             "expiretm" => 0,
             "cost" => "0.00000",
-            "fee" => "0.00000", 
-            "misc" => "", 
-            "limitprice" => "0.00000", 
-            "opentm" => 1.6730201392732968e9, 
+            "fee" => "0.00000",
+            "misc" => "",
+            "limitprice" => "0.00000",
+            "opentm" => 1.6730201392732968e9,
             "descr" => Dict{String, Any}(
                 "ordertype" => "limit",
-                "price" => "40.5842", 
-                "pair" => "DOTUSD", 
-                "order" => "buy 40.36280000 DOTUSD @ limit 4.5842", 
+                "price" => "40.5842",
+                "pair" => "DOTUSD",
+                "order" => "buy 40.36280000 DOTUSD @ limit 4.5842",
                 "leverage" => "none",
-                "type" => "buy", 
-                "close" => "", 
+                "type" => "buy",
+                "close" => "",
                 "price2" => "0"
-            ), 
+            ),
             "closetm" => 1.673225209430317e9
-        ), 
+        ),
         "OUSQ7U-2TP3Q-PBKOIP" => Dict{String, Any}(
             ...
         )
@@ -240,7 +241,8 @@ end
     get_orders_info(client::SpotBaseRESTAPI;
         txid::Union{String,Vector{String}},
         trades::Bool=false,
-        userref::Union{Int64,Nothing}=nothing
+        userref::Union{Int64,Nothing}=nothing,
+        consolidate_taker::Bool=true,
     )
 
 Kraken Docs: [https://docs.kraken.com/rest/#tag/User-Data/operation/getOrdersInfo](https://docs.kraken.com/rest/#tag/User-Data/operation/getOrdersInfo)
@@ -256,32 +258,32 @@ julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_orders_info(client, txid="OLGRP5-M42MC-YOFF7T"))
 Dict{String, Any}
     "OLGRP5-M42MC-YOFF7T" => Dict{String, Any}(
-        "price" => "0.00000", 
-        "vol" => "40.36280000", 
-        "status" => "canceled", 
-        "vol_exec" => "0.00000000", 
-        "oflags" => "fciq", 
-        "reason" => "User requested", 
-        "starttm" => 0, 
-        "stopprice" => "0.00000", 
-        "refid" => nothing, 
-        "userref" => 0, 
+        "price" => "0.00000",
+        "vol" => "40.36280000",
+        "status" => "canceled",
+        "vol_exec" => "0.00000000",
+        "oflags" => "fciq",
+        "reason" => "User requested",
+        "starttm" => 0,
+        "stopprice" => "0.00000",
+        "refid" => nothing,
+        "userref" => 0,
         "expiretm" => 0,
         "cost" => "0.00000",
-        "fee" => "0.00000", 
-        "misc" => "", 
-        "limitprice" => "0.00000", 
-        "opentm" => 1.6730201392732968e9, 
+        "fee" => "0.00000",
+        "misc" => "",
+        "limitprice" => "0.00000",
+        "opentm" => 1.6730201392732968e9,
         "descr" => Dict{String, Any}(
             "ordertype" => "limit",
-            "price" => "40.5842", 
-            "pair" => "DOTUSD", 
-            "order" => "buy 40.36280000 DOTUSD @ limit 4.5842", 
+            "price" => "40.5842",
+            "pair" => "DOTUSD",
+            "order" => "buy 40.36280000 DOTUSD @ limit 4.5842",
             "leverage" => "none",
-            "type" => "buy", 
-            "close" => "", 
+            "type" => "buy",
+            "close" => "",
             "price2" => "0"
-        ), 
+        ),
         "closetm" => 1.673225209430317e9
     )
 )
@@ -290,11 +292,13 @@ Dict{String, Any}
 function get_orders_info(client::SpotBaseRESTAPI;
     txid::Union{String,Vector{String}},
     trades::Bool=false,
-    userref::Union{Int64,Nothing}=nothing
+    userref::Union{Int64,Nothing}=nothing,
+    consolidate_taker::Bool=true
 )
     params = Dict{String,Any}(
         "txid" => vector_to_string(txid),
-        "trades" => string(trades)
+        "trades" => string(trades),
+        "consolidate_taker" => consolidate_taker
     )
     !isnothing(userref) ? params["userref"] = userref : nothing
     return request(client, "POST", "/private/QueryOrders"; data=params, auth=true)
@@ -321,21 +325,21 @@ Authenticated `client` required
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_trades_history(client, type="all", start=1668431675, trades=true))
 Dict{String, Any}(
-    "count" => 182, 
+    "count" => 182,
     "trades" => Dict{String, Any}(
         "TRZUTT-EZZ7C-NYDTL3" => Dict{String, Any}(
-            "price" => "4.29780", 
-            "time" => 1.6722627506350572e9, 
+            "price" => "4.29780",
+            "time" => 1.6722627506350572e9,
             "ordertxid" => "OGFLW2-CZKU3-XKCBMB",
-            "trade_id" => 8737419, 
-            "vol" => "46.5350000", 
-            "pair" => "DOTUSD", 
-            "postxid" => "TKH2SE-M7IF5-CFI7LT", 
-            "ordertype" => "limit", 
-            "cost" => "199.9981", 
-            "fee" => "0.3200", 
-            "misc" => "", 
-            "leverage" => "0", 
+            "trade_id" => 8737419,
+            "vol" => "46.5350000",
+            "pair" => "DOTUSD",
+            "postxid" => "TKH2SE-M7IF5-CFI7LT",
+            "ordertype" => "limit",
+            "cost" => "199.9981",
+            "fee" => "0.3200",
+            "misc" => "",
+            "leverage" => "0",
             "margin" => "0.00000",
             "type" => "buy"
         ), "TNJFKJ-YLYX7-ETYS66" => Dict{String, Any}(
@@ -367,7 +371,7 @@ end
 
 Kraken Docs: [https://docs.kraken.com/rest/#operation/getTradesInfo](https://docs.kraken.com/rest/#operation/getTradesInfo)
 
-Returns information about specific trades by `txid`. 
+Returns information about specific trades by `txid`.
 
 Authenticated `client` required
 
@@ -477,28 +481,28 @@ Authenticated `client` required
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_ledgers_info(client))
 Dict{String, Any}(
-    "count" => 1068, 
+    "count" => 1068,
     "ledger" => Dict{String, Any}(
         "LWSAYQ-GD2N2-IM3I6O" => Dict{String, Any}(
-            "amount" => "0.00", 
-            "balance" => "9437.94", 
-            "fee" => "6.43", 
-            "time" => 1.6732795570751212e9, 
-            "aclass" => "currency", 
-            "asset" => "KFEE", 
-            "subtype" => "", 
-            "refid" => "TYQEFQ-NYADC-R4LII6", 
+            "amount" => "0.00",
+            "balance" => "9437.94",
+            "fee" => "6.43",
+            "time" => 1.6732795570751212e9,
+            "aclass" => "currency",
+            "asset" => "KFEE",
+            "subtype" => "",
+            "refid" => "TYQEFQ-NYADC-R4LII6",
             "type" => "trade"
-        ), 
+        ),
         "LP6VNL-HDXPP-JLVG73" => Dict{String, Any}(
-            "amount" => "-0.0300000000", 
-            "balance" => "0.0119368320", 
-            "fee" => "0.0000000000", 
-            "time" => 1.6732795570750895e9, 
-            "aclass" => "currency", 
-            "asset" => "XETH", 
-            "subtype" => "", 
-            "refid" => "TYQEFQ-NYADC-R4LII6", 
+            "amount" => "-0.0300000000",
+            "balance" => "0.0119368320",
+            "fee" => "0.0000000000",
+            "time" => 1.6732795570750895e9,
+            "aclass" => "currency",
+            "asset" => "XETH",
+            "subtype" => "",
+            "refid" => "TYQEFQ-NYADC-R4LII6",
             "type" => "trade"
         ), ....
     )
@@ -542,13 +546,13 @@ julia> println(get_ledgers(client, id="LNYQGU-SUR5U-UXTOWM"))
 Dict{String, Any}(
     "LNYQGU-SUR5U-UXTOWM" => Dict{String, Any}(
         "amount" => "2001.0000",
-        "balance" => "2001.0082", 
-        "fee" => "0.0000", 
-        "time" => 1.668681189483613e9, 
-        "aclass" => "currency", 
-        "asset" => "EUR", 
-        "subtype" => "", 
-        "refid" => "QYSCWYA-S54CSU-RDHRV3", 
+        "balance" => "2001.0082",
+        "fee" => "0.0000",
+        "time" => 1.668681189483613e9,
+        "aclass" => "currency",
+        "asset" => "EUR",
+        "subtype" => "",
+        "refid" => "QYSCWYA-S54CSU-RDHRV3",
         "type" => "deposit"
     )
 )
@@ -576,9 +580,9 @@ Authenticated `client` required
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_trade_volume(client))
 Dict{String, Any}(
-    "currency" => "ZUSD", 
+    "currency" => "ZUSD",
     "volume" => "204212.9762",
-    "fees_maker" => nothing, 
+    "fees_maker" => nothing,
     "fees" => nothing
 )
 ```
@@ -607,7 +611,7 @@ Authenticated `client` required
 
 # Attributes
 
-- `report` -- must be one of ["trades", "ledgers"] 
+- `report` -- must be one of ["trades", "ledgers"]
 
 ...
 
@@ -617,11 +621,11 @@ Authenticated `client` required
 ```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(request_export_report(
-...        client, 
-...        report="ledgers", 
-...        description="myLedgersExport", 
+...        client,
+...        report="ledgers",
+...        description="myLedgersExport",
 ...        format="CSV"
-...    ) 
+...    )
 Dict{String, Any}("id" => "OFEZ")
 ```
 """
@@ -656,7 +660,7 @@ Authenticated `client` required
 
 # Attributes
 
-- `report` -- must be one of ["trades", "ledgers"] 
+- `report` -- must be one of ["trades", "ledgers"]
 
 ...
 
@@ -666,22 +670,22 @@ Authenticated `client` required
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
 julia> println(get_export_report_status(client, report="ledgers"))
 Any[Dict{String, Any}(
-    "report" => "ledgers", 
-    "fields" => "all", 
-    "aclass" => "currency", 
-    "endtm" => "1673368394", 
-    "createdtm" => "1673368394", 
-    "format" => "CSV", 
-    "status" => "Queued", 
-    "id" => "OFEZ", 
-    "subtype" => "all", 
+    "report" => "ledgers",
+    "fields" => "all",
+    "aclass" => "currency",
+    "endtm" => "1673368394",
+    "createdtm" => "1673368394",
+    "format" => "CSV",
+    "status" => "Queued",
+    "id" => "OFEZ",
+    "subtype" => "all",
     "starttm" => "1672531200",
-    "dataendtm" => "1673368394", 
-    "completedtm" => "0", 
-    "datastarttm" => "1672531200", 
-    "expiretm" => "1674577994", 
-    "flags" => "0", 
-    "asset" => "all", 
+    "dataendtm" => "1673368394",
+    "completedtm" => "0",
+    "datastarttm" => "1672531200",
+    "expiretm" => "1674577994",
+    "flags" => "0",
+    "asset" => "all",
     "descr" => "myLedgersExport"
 )]
 ```
@@ -706,7 +710,7 @@ The `id` is obtained when requesting the report using [`request_export_report`](
 
 ```julia-repl
 julia> client = SpotBaseRESTAPI(key="api-key", secret="secret-key")
-julia> report = retrieve_export(private_client, id="OFEZ") 
+julia> report = retrieve_export(private_client, id="OFEZ")
 julia> open("myExport.zip", "w") do io
 ...        write(io, report)
 ...    end
@@ -751,7 +755,7 @@ end
 
 Kraken Docs: [https://docs.kraken.com/rest/#tag/Websockets-Authentication](https://docs.kraken.com/rest/#tag/Websockets-Authentication)
 
-Returns the websocket token. This is used by the when 
+Returns the websocket token. This is used by the when
 managing private websocket feeds and subscriptions.
 
 Authenticated `client` required
@@ -770,4 +774,25 @@ Dict{String,Any}(
 function get_websockets_token(client::SpotBaseRESTAPI)
     return request(client, "POST", "/private/GetWebSocketsToken", auth=true)
 end
+
+"""
+    create_subaccount(client::SpotBaseRESTAPI, username::String, email::String)
+
+Kraken Docs: [https://docs.kraken.com/rest/#tag/User-Subaccounts](https://docs.kraken.com/rest/#tag/User-Subaccountsc
+)
+
+Create a subaccount for trading. This is currently *only available
+for institutional clients*.
+
+Authenticated `client` required
+"""
+function create_subaccount(client::SpotBaseRESTAPI, username::String, email::String)
+    return request(
+        client,
+        "POST",
+        "private/CreateSubaccount",
+        params=Dict{String,String}("username" => username, "email" => email)
+    )
 end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,11 +24,11 @@ using Test
 
     @test typeof(SpotMarket.get_order_book(client, pair="XBTUSD")) == Dict{String,Any}
 
-    @test typeof(SpotMarket.get_recend_spreads(client, pair="XBTUSD")) == Dict{String,Any}
+    @test typeof(SpotMarket.get_recent_spreads(client, pair="XBTUSD")) == Dict{String,Any}
 
     @test typeof(SpotMarket.get_system_status(client)) == Dict{String,Any}
 
-    # ... 
+    # ...
 end
 
 @testset "KrakenEx Futures REST Market Endpoints" begin
@@ -69,5 +69,5 @@ end
     @test typeof(FuturesMarket.get_trade_history(client, symbol="PI_XBTUSD")) == Dict{String,Any}
 
     @test typeof(FuturesMarket.get_public_execution_events(client, tradeable="PI_XBTUSD")) == Dict{String,Any}
-    # ... 
+    # ...
 end


### PR DESCRIPTION
# Summary
- Fixed typos - "recend" => "recent" (Breaking).
- Added the parameters "reduce_only" and "displayvol" to Spot/Trade/create_order.  
- Added "create_subaccount" to Spot/User